### PR TITLE
Added DataCite support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ALA DOI Service
-ALA DOI minting service - integrates with ANDS to produce the DOI, provides a landing page, and stores the associated file
+ALA DOI minting service - integrates with ANDS or DataCite to produce the DOI, provides a landing page, and stores the associated file
 
 Master: [![Build Status](https://travis-ci.org/AtlasOfLivingAustralia/doi-service.svg?branch=master)](https://travis-ci.org/AtlasOfLivingAustralia/doi-service)
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ repositories {
     mavenLocal()
     maven { url "https://nexus.ala.org.au/content/groups/public/" }
     maven { url "https://repo.grails.org/grails/core" }
+    maven { url "https://repository.gbif.org/content/groups/gbif/" }
 }
 
 // Inplace plugin config
@@ -54,6 +55,9 @@ if(inplace) {
 
 def elasticsearchVersion = '5.4.3'
 ext['elasticsearch.version'] = elasticsearchVersion
+// To prevent: http://hg.openjdk.java.net/jdk8/jdk8/jaxp/rev/5c84d4a878f1
+// when using gbif-doi datacite xml validator
+def withoutXerces = { exclude group: 'xerces', module: 'xercesImpl' }
 
 dependencies {
     compile "org.springframework.boot:spring-boot-starter-logging"
@@ -76,6 +80,7 @@ dependencies {
     compile "org.grails.plugins:hibernate5"
     compile "org.hibernate:hibernate-core:5.1.5.Final"
     compile "org.grails.plugins:gsp"
+    compile "org.gbif:gbif-doi:2.9"
     console "org.grails:grails-console"
     profile "org.grails.profiles:web"
     runtime "org.glassfish.web:el-impl:2.1.2-b03"
@@ -85,8 +90,8 @@ dependencies {
     testCompile "org.grails:grails-gorm-testing-support"
     testCompile "org.grails.plugins:geb"
     testCompile "org.grails:grails-web-testing-support"
-    testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"
-    testRuntime "net.sourceforge.htmlunit:htmlunit:2.18"
+    testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1", withoutXerces
+    testRuntime "net.sourceforge.htmlunit:htmlunit:2.18", withoutXerces
 
     compile "org.grails.plugins:converters"
     compile 'org.grails.plugins:external-config:1.1.2'
@@ -95,7 +100,7 @@ dependencies {
     runtime 'org.elasticsearch.plugin:mapper-attachments:2.4.6'
 
     compile "org.grails.plugins:ala-ws-security-plugin:2.0"
-    compile "org.grails.plugins:ala-ws-plugin:2.0"
+    compile "org.grails.plugins:ala-ws-plugin:2.0", withoutXerces
     if(!inplace) {
         compile "org.grails.plugins:ala-auth:3.0.4"
     }
@@ -149,4 +154,8 @@ bootRepackage {
 assets {
     minifyJs = true
     minifyCss = true
+}
+
+war {
+    exclude "xerces/**/**"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,3 @@ assets {
     minifyJs = true
     minifyCss = true
 }
-
-war {
-    exclude "xerces/**/**"
-}

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -109,6 +109,13 @@ environments:
         doi:
             service:
                 mock: true
+        datacite:
+            doi:
+                service:
+                    baseApiUrl: https://api.test.datacite.org/
+                    user: XXXXX
+                    password: XXXXX
+                    prefix: 10.XXXXX
     test:
         flyway:
             enabled: false # TODO is necessary?
@@ -159,6 +166,16 @@ ands:
         client:
             id: xx
 
+datacite:
+    doi:
+        service:
+            baseApiUrl: https://api.datacite.org/
+            user: XXXXX
+            password: XXXXX
+            fileCacheMaxSizeMb: 64
+            timeOut: 60
+            prefix: 10.XXXXX
+            shoulder: ala
 ala:
     base:
         url: https://ala.org.au
@@ -167,6 +184,8 @@ ala:
 doi:
     service:
         mock: false
+        # ANDS or DATACITE
+        provider: ANDS
     storage:
         provider: LOCAL
         cloud:

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -196,6 +196,7 @@ doi:
       - "biocache"
       - "phylolink"
       - "csdm"
+    publicationLang: "en"
 file:
     store: /data/doi-service/files
 

--- a/grails-app/controllers/au/org/ala/doi/ui/AdminController.groovy
+++ b/grails-app/controllers/au/org/ala/doi/ui/AdminController.groovy
@@ -79,7 +79,7 @@ class AdminController {
             def provider
             if (params?.newExistingDoiRadio == "existing") {
                 checkArgument params.existingDoi, "Existing DOI is required if registering an existing DOI"
-                provider = DoiProvider.ANDS
+                provider = DoiProvider.byName(params.provider)
             } else {
                 checkArgument params.providerMetadata, "Provider metadata is required if minting a new DOI"
                 checkArgument params.provider, "Provider is required if minting a new DOI"

--- a/grails-app/domain/au/org/ala/doi/Doi.groovy
+++ b/grails-app/domain/au/org/ala/doi/Doi.groovy
@@ -65,7 +65,7 @@ class Doi {
 
     static mapping = {
         doi type: CitextType
-        provider defaultValue: DoiProvider.forName(Holders.config.doi.service.provider)
+        provider defaultValue: DoiProvider.byName(Holders.config.doi.service.provider as String)
         providerMetadata type: JsonbMapType
         applicationMetadata type: JsonbMapType
         active defaultValue: true

--- a/grails-app/domain/au/org/ala/doi/Doi.groovy
+++ b/grails-app/domain/au/org/ala/doi/Doi.groovy
@@ -2,6 +2,7 @@ package au.org.ala.doi
 
 import au.org.ala.doi.ArrayType
 import au.org.ala.doi.util.DoiProvider
+import grails.util.Holders
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import net.kaleidos.hibernate.usertype.JsonbMapType
@@ -64,7 +65,7 @@ class Doi {
 
     static mapping = {
         doi type: CitextType
-        provider defaultValue: DoiProvider.ANDS
+        provider defaultValue: DoiProvider.forName(Holders.config.doi.service.provider)
         providerMetadata type: JsonbMapType
         applicationMetadata type: JsonbMapType
         active defaultValue: true

--- a/grails-app/services/au/org/ala/doi/DoiService.groovy
+++ b/grails-app/services/au/org/ala/doi/DoiService.groovy
@@ -42,7 +42,7 @@ class DoiService extends BaseDataAccessService {
                 Map applicationMetadata = [:], String customLandingPageUrl = null, String defaultDoi = null,
                 String userId = null, Boolean active = true, List<String> authorisedRoles=[], String displayTemplate = null) {
         checkArgument provider
-        log.info("Trying to mint with provider: $provider")
+        log.debug("Trying to mint with provider: $provider")
         if(!defaultDoi) {
             checkArgument providerMetadata, "No provider metadata has been sent"
         }
@@ -204,7 +204,6 @@ class DoiService extends BaseDataAccessService {
     // Replace this with a factory if/when other DOI providers are supported
     private DoiProviderService getProviderService(DoiProvider provider) {
         DoiProviderService service
-        log.info("Get provider for $provider")
         if (useMockDoiService) {
             log.info("Using mock provider service")
             return mockService

--- a/grails-app/services/au/org/ala/doi/DoiService.groovy
+++ b/grails-app/services/au/org/ala/doi/DoiService.groovy
@@ -5,6 +5,7 @@ import au.org.ala.doi.exceptions.DoiNotFoundException
 import au.org.ala.doi.exceptions.DoiUpdateException
 import au.org.ala.doi.exceptions.DoiValidationException
 import au.org.ala.doi.providers.AndsService
+import au.org.ala.doi.providers.DataCiteService
 import au.org.ala.doi.providers.DoiProviderService
 import au.org.ala.doi.providers.MockService
 import au.org.ala.doi.storage.Storage
@@ -23,8 +24,9 @@ import static au.org.ala.doi.util.Utils.isUuid
 class DoiService extends BaseDataAccessService {
 
     GrailsApplication grailsApplication
-    AndsService andsService
-    MockService mockService
+    AndsService andsService = new AndsService()
+    DataCiteService dataCiteService = new DataCiteService()
+    MockService mockService = new MockService()
     Storage storage
     EmailService emailService
     DoiSearchService doiSearchService
@@ -40,6 +42,7 @@ class DoiService extends BaseDataAccessService {
                 Map applicationMetadata = [:], String customLandingPageUrl = null, String defaultDoi = null,
                 String userId = null, Boolean active = true, List<String> authorisedRoles=[], String displayTemplate = null) {
         checkArgument provider
+        log.info("Trying to mint with provider: $provider")
         if(!defaultDoi) {
             checkArgument providerMetadata, "No provider metadata has been sent"
         }
@@ -201,8 +204,9 @@ class DoiService extends BaseDataAccessService {
     // Replace this with a factory if/when other DOI providers are supported
     private DoiProviderService getProviderService(DoiProvider provider) {
         DoiProviderService service
-
+        log.info("Get provider for $provider")
         if (useMockDoiService) {
+            log.info("Using mock provider service")
             return mockService
         }
 
@@ -210,8 +214,10 @@ class DoiService extends BaseDataAccessService {
             case DoiProvider.ANDS:
                 service = andsService
                 break
+            case DoiProvider.DATACITE:
+                service = dataCiteService
+                break
         }
-
         service
     }
 }

--- a/grails-app/services/au/org/ala/doi/DoiService.groovy
+++ b/grails-app/services/au/org/ala/doi/DoiService.groovy
@@ -24,9 +24,9 @@ import static au.org.ala.doi.util.Utils.isUuid
 class DoiService extends BaseDataAccessService {
 
     GrailsApplication grailsApplication
-    AndsService andsService = new AndsService()
-    DataCiteService dataCiteService = new DataCiteService()
-    MockService mockService = new MockService()
+    AndsService andsService
+    DataCiteService dataCiteService
+    MockService mockService
     Storage storage
     EmailService emailService
     DoiSearchService doiSearchService

--- a/grails-app/services/au/org/ala/doi/providers/AndsService.groovy
+++ b/grails-app/services/au/org/ala/doi/providers/AndsService.groovy
@@ -229,7 +229,7 @@ class AndsService extends DoiProviderService {
     }
 
 
-    def generateRequestPayload(Map metadata, String landingPageUrl, String doi = null) {
+    def generateRequestPayload(String uuid, Map metadata, String landingPageUrl, String doi = null) {
         StringWriter writer = new StringWriter()
 
         def doiValue = doi ?: "10.5072/example" // doi is a mandatory element in the schema, in a mint request the value is ignored

--- a/grails-app/services/au/org/ala/doi/providers/DataCiteService.groovy
+++ b/grails-app/services/au/org/ala/doi/providers/DataCiteService.groovy
@@ -1,0 +1,209 @@
+package au.org.ala.doi.providers
+
+import au.org.ala.doi.util.ServiceResponse
+import org.gbif.api.model.common.DOI
+import org.gbif.datacite.rest.client.configuration.ClientConfiguration
+import grails.util.Holders
+
+import org.gbif.datacite.rest.client.retrofit.DataCiteRetrofitSyncClient
+import org.gbif.doi.metadata.datacite.ContributorType
+import org.gbif.doi.metadata.datacite.DataCiteMetadata
+import org.gbif.doi.metadata.datacite.DataCiteMetadata.Creators.Creator
+import org.gbif.doi.metadata.datacite.DataCiteMetadata.Titles
+import org.gbif.doi.metadata.datacite.DateType
+import org.gbif.doi.metadata.datacite.DescriptionType
+import org.gbif.doi.metadata.datacite.TitleType
+import org.gbif.doi.service.datacite.RestJsonApiDataCiteService;
+
+import static org.gbif.doi.metadata.datacite.DataCiteMetadata.*
+import static org.gbif.doi.metadata.datacite.DataCiteMetadata.RightsList.*
+import static org.gbif.doi.metadata.datacite.DataCiteMetadata.Titles.*
+
+class DataCiteService extends DoiProviderService {
+
+    RestJsonApiDataCiteService restDataCiteService
+    ClientConfiguration clientConf = ClientConfiguration.builder().withBaseApiUrl(
+            Holders.config.datacite.doi.service.baseApiUrl as String).withTimeOut(
+            Holders.config.datacite.doi.service.timeOut as long).withFileCacheMaxSizeMb(
+            Holders.config.datacite.doi.service.fileCacheMaxSizeMb as long).withUser(
+            Holders.config.datacite.doi.service.user as String).withPassword(
+            Holders.config.datacite.doi.service.password as String).build()
+
+    DataCiteService() {
+        def dataCiteClient = new DataCiteRetrofitSyncClient(clientConf)
+        restDataCiteService = new RestJsonApiDataCiteService(dataCiteClient)
+        log.info "Using $Holders.config.datacite.doi.service.baseApiUrl baseApiUrl"
+    }
+
+    def generateRequestPayload(String uuid, Map metadata, String landingPageUrl, String doi = null) {
+        def dcMetadata = new DataCiteMetadata();
+
+        // doi is a mandatory element in the schema, in a ANDS mint request the value is ignored
+        // so here we generate one using prefix/shoulder.uuid
+        def doiValue = doi ?: "${Holders.config.datacite.doi.service.prefix}/${Holders.config.datacite.doi.service.shoulder}.${uuid}"
+        def id = new Identifier()
+        id.setValue(doiValue as String)
+        id.setIdentifierType("DOI")
+        dcMetadata.setIdentifier(id)
+
+        // Creators
+        def creators = new Creators()
+        if (metadata.creators) {
+            for (def creator in metadata.creators) {
+                def dcCreator = new Creator()
+                def dcCreatorName = new Creator.CreatorName()
+                dcCreatorName.setValue(creator.name as String)
+                dcCreator.setCreatorName(dcCreatorName)
+                creators.creator.add(dcCreator)
+            }
+        }
+        // We add also authors as creators like AndsService
+        if (metadata.authors) {
+            for (def author in metadata.authors) {
+                def dcCreator = new Creator()
+                def dcCreatorName = new Creator.CreatorName()
+                dcCreatorName.setValue(author as String)
+                dcCreator.setCreatorName(dcCreatorName)
+                creators.creator.add(dcCreator)
+            }
+        }
+        dcMetadata.setCreators(creators)
+
+        // Titles
+        def titles = new Titles()
+        if (metadata.titles) {
+            for (def title in metadata.titles) {
+                def dcTitle = new Title()
+                dcTitle.setValue(title.title as String)
+                titles.title.add(dcTitle)
+            }
+        }
+        // Adding v3 title as AndsService
+        if (metadata.title) {
+            def dcTitle = new Title()
+            dcTitle.setValue(metadata.title as String)
+            titles.title.add(dcTitle)
+        }
+        if (metadata.subtitle) {
+            def sub = new Title();
+            sub.setValue("${metadata.subtitle}")
+            sub.setTitleType(TitleType.SUBTITLE)
+            titles.title.add(sub)
+        }
+        dcMetadata.setTitles(titles)
+
+        def publisher = new Publisher()
+        publisher.setValue("${metadata.publisher}")
+        dcMetadata.setPublisher(publisher)
+
+        dcMetadata.setPublicationYear((String) metadata.publicationYear ?: Calendar.getInstance().get(Calendar.YEAR).toString())
+
+        // Subjects
+        if (metadata.subjects) {
+            def subjects = new Subjects()
+            metadata.subjects.each {
+                    def subject = new Subjects.Subject()
+                    subject.setValue((String) it)
+                    subjects.subject.add(subject)
+            }
+            dcMetadata.setSubjects(subjects)
+        }
+
+        // Contributors
+        if (metadata.contributors) {
+            def contributors = new Contributors()
+            for (contrib in metadata.contributors) {
+                def contributor = new Contributors.Contributor()
+                def contributorType = ContributorType.fromValue(contrib.type as String)
+                contributor.setContributorType(contributorType)
+                def cName = new Contributors.Contributor.ContributorName()
+                cName.setValue(contrib.name as String)
+                contributor.setContributorName(cName)
+                contributors.contributor.add(contributor)
+            }
+            dcMetadata.setContributors(contributors)
+        }
+
+
+        // Created dates
+        if (metadata.createdDate) {
+            def dates = new Dates()
+            def createdDate = new Dates.Date()
+            createdDate.setDateType(DateType.CREATED)
+            createdDate.setValue(metadata.createdDate as String)
+            dates.date.add(createdDate)
+            dcMetadata.setDates(dates)
+        }
+
+        // Rights
+        if (metadata.rights) {
+            def rightsList = new RightsList()
+            metadata.rights.each {
+                def rights = new Rights()
+                rights.setValue((String) it)
+                rightsList.rights.add(rights)
+            }
+            dcMetadata.setRightsList(rightsList)
+        }
+
+        // FIXME put lang in config
+        dcMetadata.setLanguage("en")
+
+        // ResourceType
+        def resourceType = new ResourceType();
+        def resourceTypeGeneral = org.gbif.doi.metadata.datacite.ResourceType.fromValue(metadata.resourceType as String);
+        resourceType.setValue(metadata.resourceText as String)
+        resourceType.setResourceTypeGeneral(resourceTypeGeneral)
+        dcMetadata.setResourceType(resourceType)
+
+        // Descriptions
+        if (metadata.descriptions) {
+            def descriptions = new Descriptions()
+            metadata.descriptions.each {
+                def description = new Descriptions.Description()
+                def descriptionType = DescriptionType.fromValue(it.type as String)
+                description.getContent().add(it.text as String)
+                description.setDescriptionType(descriptionType)
+                descriptions.description.add(description)
+            }
+            dcMetadata.setDescriptions(descriptions)
+        }
+
+        return dcMetadata
+    }
+
+    @Override
+    ServiceResponse invokeCreateService(Object requestPayload, String landingPageUrl) {
+        def dcMetadata = requestPayload as DataCiteMetadata
+        def doiS = dcMetadata.getIdentifier().getValue()
+        def doi = new DOI(doiS)
+        // restDataCiteService.reserve(doi, dcMetadata)
+        restDataCiteService.register(doi, new URI(landingPageUrl), dcMetadata)
+        def response = new ServiceResponse(200, '', "")
+        response.doi = doiS
+        return response
+    }
+
+    @Override
+    ServiceResponse invokeUpdateService(String doi, Map requestPayload, String landingPageUrl) {
+        return successResponse()
+    }
+
+    @Override
+    ServiceResponse invokeDeactivateService(String doi) {
+        service.
+        return successResponse()
+    }
+
+    @Override
+    ServiceResponse invokeActivateService(String doi) {
+        return successResponse()
+    }
+
+    @Deprecated
+    ServiceResponse successResponse() {
+        def response = new ServiceResponse(200, '', "ABC")
+        response.doi = "10.1000/${UUID.randomUUID()}"
+        return response
+    }
+}

--- a/grails-app/services/au/org/ala/doi/providers/DataCiteService.groovy
+++ b/grails-app/services/au/org/ala/doi/providers/DataCiteService.groovy
@@ -186,8 +186,7 @@ class DataCiteService extends DoiProviderService {
         def doi = new DOI(doiS)
         try {
             restDataCiteService.register(doi, new URI(landingPageUrl), dcMetadata)
-
-            return response
+            return successResponse(doiS)
         } catch (Exception e) {
             return processErrorResponse(doi, e)
         }
@@ -229,7 +228,7 @@ class DataCiteService extends DoiProviderService {
                 processErrorResponse(doi, e)
             }
         }
-        return successResponse()
+        return successResponse(doiS)
     }
 
     @Override

--- a/grails-app/services/au/org/ala/doi/providers/DoiProviderService.groovy
+++ b/grails-app/services/au/org/ala/doi/providers/DoiProviderService.groovy
@@ -35,7 +35,7 @@ abstract class DoiProviderService {
 
         def requestPayload
         try {
-            requestPayload = generateRequestPayload(metadata, landingPageUrl)
+            requestPayload = generateRequestPayload(uuid, metadata, landingPageUrl)
         } catch (Exception e) {
             log.error('Failed to construct the provider request payload', e)
             throw new DoiMintingException("Failed to construct the provider request payload", e)
@@ -73,7 +73,7 @@ abstract class DoiProviderService {
         def requestPayload
         if (metadata) {
             try {
-                requestPayload = generateRequestPayload(metadata, landingPageUrl, doi)
+                requestPayload = generateRequestPayload(uuid, metadata, landingPageUrl, doi)
             } catch (Exception e) {
                 log.error('Failed to construct the provider request payload', e)
                 throw new DoiMintingException("Failed to construct the provider request payload", e)
@@ -138,11 +138,12 @@ abstract class DoiProviderService {
     /**
      * Convert the provider metadata Map into whatever format is required for the web service (e.g. JSON, XML, etc)
      *
+     * @param uuid The local unique identifier for the DOI
      * @param metadata The provider metadata required by the DOI Provider
      * @param landingPageUrl The landing page that the DOI needs to resolve to
      * @return The payload for the DOI minting request to be sent to the provider
      */
-    abstract def generateRequestPayload(Map metadata, String landingPageUrl, String doi = null)
+    abstract def generateRequestPayload(String uuid, Map metadata, String landingPageUrl, String doi = null)
 
     /**
      * Invoke the DOI provider's minting service, passing it the payload constructed in {@link #generateRequestPayload(java.util.Map, java.lang.String)}

--- a/grails-app/services/au/org/ala/doi/providers/MockService.groovy
+++ b/grails-app/services/au/org/ala/doi/providers/MockService.groovy
@@ -5,7 +5,7 @@ import au.org.ala.doi.util.ServiceResponse
 class MockService extends DoiProviderService {
 
     @Override
-    def generateRequestPayload(Map metadata, String landingPageUrl, String doi) {
+    def generateRequestPayload(String uuid, Map metadata, String landingPageUrl, String doi) {
         return [:]
     }
 

--- a/src/main/groovy/au/org/ala/doi/util/DoiProvider.groovy
+++ b/src/main/groovy/au/org/ala/doi/util/DoiProvider.groovy
@@ -2,7 +2,8 @@ package au.org.ala.doi.util
 
 enum DoiProvider {
 
-    ANDS
+    ANDS,
+    DATACITE
 
     static DoiProvider byName(String name) {
         values().find { it.name().equalsIgnoreCase(name) }

--- a/src/test/groovy/au/org/ala/doi/providers/AndsServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/doi/providers/AndsServiceSpec.groovy
@@ -182,7 +182,7 @@ class AndsServiceSpec extends Specification implements ServiceUnitTest<AndsServi
         String expectedXml = Resources.getResource('resources/ValidANDSRequest.xml').text
 
         when:
-        String xml = service.generateRequestPayload(andsMetadata, "landingPageUrl")
+        String xml = service.generateRequestPayload("uuid", andsMetadata, "landingPageUrl")
 
         then:
         standardizeSpaces(xml) == standardizeSpaces(expectedXml)

--- a/src/test/groovy/au/org/ala/doi/providers/DataCiteServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/doi/providers/DataCiteServiceSpec.groovy
@@ -1,0 +1,69 @@
+package au.org.ala.doi.providers
+
+import com.google.common.io.Resources
+import grails.testing.services.ServiceUnitTest
+import grails.util.Holders
+import grails.web.mapping.LinkGenerator
+import org.gbif.datacite.rest.client.configuration.ClientConfiguration
+import org.gbif.doi.metadata.datacite.DataCiteMetadata
+import org.gbif.doi.metadata.datacite.DateType
+import org.gbif.doi.metadata.datacite.TitleType
+import org.gbif.doi.service.datacite.DataCiteValidator
+import org.gbif.doi.service.datacite.RestJsonApiDataCiteService
+import org.grails.spring.beans.factory.InstanceFactoryBean
+import spock.lang.Specification
+import spock.lang.Unroll
+
+
+@Unroll
+class DataCiteServiceSpec extends Specification implements ServiceUnitTest<DataCiteService> {
+
+    def setup() {
+        defineBeans {
+            grailsLinkGenerator(InstanceFactoryBean, Stub(LinkGenerator), LinkGenerator)
+        }
+        service.restDataCiteService = Mock(RestJsonApiDataCiteService)
+        service.clientConf = ClientConfiguration.builder()
+                .withBaseApiUrl("https://api.test.datacite.org/")
+                .withTimeOut(60)
+                .withFileCacheMaxSizeMb(64)
+                .withUser("bob").withPassword("12345").build()
+    }
+
+    def "generateRequestPayload should map all metadata fields to the DataCite xml schema"() {
+        given:
+        Map metadataMap = [:]
+        def uuid = UUID.randomUUID()
+        metadataMap.authors = ["author1", "author2"]
+        metadataMap.title = "publicationTitle"
+        metadataMap.subtitle = "publicationSubtitle"
+        metadataMap.publisher = "publisherName"
+        metadataMap.publicationYear = "2016"
+        metadataMap.subjects = ["subject1", "subject2"]
+        metadataMap.contributors = [[type: "Editor", name: "bob"], [type: "Editor", name: "jill"]]
+        metadataMap.resourceType = "Text"
+        metadataMap.resourceText = "resourceText"
+        metadataMap.descriptions = [[type: "Other", text: "description1"], [type: "Other", text: "description2"]]
+        metadataMap.createdDate = "createdDate"
+        metadataMap.rights = ["rights statement 1", "rights statement 2"]
+
+        when:
+        DataCiteMetadata dcMetadata = service.generateRequestPayload(uuid.toString(), metadataMap, "landingPageUrl")
+
+        then:
+        dcMetadata.identifier.getIdentifierType() == "DOI"
+        dcMetadata.identifier.getValue() == "${Holders.config.datacite.doi.service.prefix}/${Holders.config.datacite.doi.service.shoulder}.${uuid}"
+        dcMetadata.titles.getTitle().get(0).getValue() == metadataMap.title
+        dcMetadata.titles.getTitle().get(1).getValue() == metadataMap.subtitle
+        dcMetadata.titles.getTitle().get(1).getTitleType() == TitleType.SUBTITLE
+        dcMetadata.creators.getCreator().get(0).getCreatorName().getValue() == (metadataMap.authors as String[])[0]
+        dcMetadata.creators.getCreator().get(1).getCreatorName().getValue() == (metadataMap.authors as String[])[1]
+        dcMetadata.publisher.getValue() == metadataMap.publisher
+        dcMetadata.publicationYear == metadataMap.publicationYear
+        dcMetadata.resourceType.getResourceTypeGeneral().value() == metadataMap.resourceType
+        dcMetadata.resourceType.getValue() == metadataMap.resourceText
+        dcMetadata.dates.getDate().get(0).getValue() == metadataMap.createdDate
+        dcMetadata.dates.getDate().get(0).getDateType() == DateType.CREATED
+        DataCiteValidator.toXml(dcMetadata, true)
+    }
+}

--- a/src/test/groovy/au/org/ala/doi/providers/DataCiteServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/doi/providers/DataCiteServiceSpec.groovy
@@ -9,16 +9,13 @@ import org.apache.http.HttpStatus
 import org.gbif.api.model.common.DoiData
 import org.gbif.api.model.common.DoiStatus
 import org.gbif.datacite.rest.client.DataCiteClient
-import org.gbif.datacite.rest.client.configuration.ClientConfiguration
 import org.gbif.doi.metadata.datacite.DataCiteMetadata
 import org.gbif.doi.metadata.datacite.DateType
 import org.gbif.doi.metadata.datacite.TitleType
-import org.gbif.doi.service.DoiExistsException
 import org.gbif.doi.service.DoiHttpException
 import org.gbif.doi.service.datacite.DataCiteValidator
 import org.gbif.doi.service.datacite.RestJsonApiDataCiteService
 import org.grails.spring.beans.factory.InstanceFactoryBean
-import retrofit2.http.DELETE
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -33,11 +30,6 @@ class DataCiteServiceSpec extends Specification implements ServiceUnitTest<DataC
 
         service.dataCiteClient = Mock(DataCiteClient)
         service.restDataCiteService = Mock(RestJsonApiDataCiteService)
-        service.clientConf = ClientConfiguration.builder()
-                .withBaseApiUrl("https://api.test.datacite.org/")
-                .withTimeOut(60)
-                .withFileCacheMaxSizeMb(64)
-                .withUser("bob").withPassword("12345").build()
     }
 
 

--- a/src/test/groovy/au/org/ala/doi/providers/DoiProviderServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/doi/providers/DoiProviderServiceSpec.groovy
@@ -10,7 +10,7 @@ class DoiProviderServiceSpec extends Specification {
     def "generateLandingPageUrl should return the customLandingPageUrl if provided"() {
         given:
         DoiProviderService service = [
-                generateRequestPayload: { metadata, landingPage -> "payload"},
+                generateRequestPayload: { uuid, metadata, landingPage -> "payload"},
                 invokeCreateService: {}
         ] as DoiProviderService
 
@@ -24,7 +24,7 @@ class DoiProviderServiceSpec extends Specification {
     def "generateLandingPageUrl should return a standard, constructed URL when there is no customLandingPageUrl"() {
         given:
         DoiProviderService service = [
-                generateRequestPayload: { metadata, landingPage -> "payload"},
+                generateRequestPayload: { uuid, metadata, landingPage -> "payload"},
                 invokeCreateService: {},
                 generateLandingPageUrl: {"serverUrl/doi/uuid1"}
         ] as DoiProviderService
@@ -69,7 +69,7 @@ class DoiProviderServiceSpec extends Specification {
     def "mintDoi should throw a DoiMintingException if generateRequestPayload results in an exception"() {
         given:
         DoiProviderService service = [
-                generateRequestPayload: { Map m, String s -> throw new Exception("test")},
+                generateRequestPayload: { uuid, Map m, String s -> throw new Exception("test")},
                 invokeCreateService: {},
                 generateLandingPageUrl: {uuid, custom -> "serverUrl/doi/uuid1"}
         ] as DoiProviderService
@@ -84,7 +84,7 @@ class DoiProviderServiceSpec extends Specification {
     def "mintDoi should throw a DoiMintingException if invokeService results in an exception"() {
         given:
         DoiProviderService service = [
-                generateRequestPayload: { Map metadata, String landingPage -> "payload"},
+                generateRequestPayload: { uuid, Map metadata, String landingPage -> "payload"},
                 invokeCreateService: { String s, String t ->  throw new Exception("test")},
                 generateLandingPageUrl: {uuid, custom -> "serverUrl/doi/uuid1"}
         ] as DoiProviderService
@@ -99,7 +99,7 @@ class DoiProviderServiceSpec extends Specification {
     def "mintDoi should throw a DoiMintingException if invokeService returns a ServiceResponse with a result code other than HTTP 200"() {
         given:
         DoiProviderService service = [
-                generateRequestPayload: { metadata, landingPage -> "payload"},
+                generateRequestPayload: { uuid, metadata, landingPage -> "payload"},
                 invokeCreateService: { payload, landingPage -> new ServiceResponse(HttpStatus.SC_BAD_REQUEST, "bad")},
                 generateLandingPageUrl: {uuid, custom -> "serverUrl/doi/uuid1"}
         ] as DoiProviderService
@@ -114,7 +114,7 @@ class DoiProviderServiceSpec extends Specification {
     def "mintDoi should throw a DoiMintingException if invokeService returns a ServiceResponse with a result code of HTTP 200 but not DOI"() {
         given:
         DoiProviderService service = [
-                generateRequestPayload: { metadata, landingPage -> "payload"},
+                generateRequestPayload: { uuid, metadata, landingPage -> "payload"},
                 invokeCreateService: { payload, landingPage -> new ServiceResponse(HttpStatus.SC_OK, "bad")},
                 generateLandingPageUrl: {uuid, custom -> "serverUrl/doi/uuid1"}
         ] as DoiProviderService
@@ -129,7 +129,7 @@ class DoiProviderServiceSpec extends Specification {
     def "mintDoi should return the new DOI on success"() {
         given:
         DoiProviderService service = [
-                generateRequestPayload: { metadata, landingPage -> "payload"},
+                generateRequestPayload: { uuid, metadata, landingPage -> "payload"},
                 invokeCreateService: { payload, landingPage -> new ServiceResponse("newDoi")},
                 generateLandingPageUrl: {uuid, custom -> "serverUrl/doi/uuid1"}
         ] as DoiProviderService


### PR DESCRIPTION
I added DataCite support using the [gbif-doi](https://github.com/gbif/gbif-doi) library (thanks to @timrobertson100 for the suggestion and for help providing me some test datacite account).

I tested minting test DOIs using `api.test.datacite.org` but in short I'll try with the production API in:
https://doi.gbif.es

I'll also send an additional PR to `ala-install` to allow the configuration of the new variables.
