### PR TITLE
issue #58 ALA banner appears twice

### DIFF
--- a/grails-app/views/admin/index.gsp
+++ b/grails-app/views/admin/index.gsp
@@ -16,7 +16,6 @@
     <asset:stylesheet src="doi.css"/>
 </head>
 <body>
-<ala:systemMessage/>
 <div class="col-sm-12">
     <h2 class="heading-medium">DOI Service Administration</h2>
 

--- a/grails-app/views/admin/mintDoi.gsp
+++ b/grails-app/views/admin/mintDoi.gsp
@@ -18,7 +18,6 @@
 </head>
 
 <body>
-<ala:systemMessage/>
 
 <div class="col-sm-12">
 

--- a/grails-app/views/doiResolve/_default.gsp
+++ b/grails-app/views/doiResolve/_default.gsp
@@ -27,7 +27,6 @@
 </head>
 
 <body>
-<ala:systemMessage/>
 
 <div class="col-sm-12 col-md-9 col-lg-9">
     <h1 class="heading-medium ${doi.active? '': 'text-muted'}">${doi.title}

--- a/grails-app/views/doiResolve/_phylolink.gsp
+++ b/grails-app/views/doiResolve/_phylolink.gsp
@@ -15,7 +15,6 @@
 </head>
 
 <body>
-<ala:systemMessage/>
 
 <div class="col-sm-12 col-md-9 col-lg-9">
     <div class="col-md-12" id="doiTitle">

--- a/grails-app/views/doiResolve/doi.gsp
+++ b/grails-app/views/doiResolve/doi.gsp
@@ -29,7 +29,6 @@
 </head>
 
 <body>
-<ala:systemMessage/>
 <div>
 
     <g:render template="${displayTemplate}" />

--- a/grails-app/views/doiResolve/index.gsp
+++ b/grails-app/views/doiResolve/index.gsp
@@ -27,7 +27,6 @@
 </head>
 
 <body>
-<ala:systemMessage/>
 
 <div class="col-sm-12 col-md-9 col-lg-9">
     <div class="row">

--- a/grails-app/views/doiResolve/unauthorisedDownload.gsp
+++ b/grails-app/views/doiResolve/unauthorisedDownload.gsp
@@ -15,7 +15,6 @@
 </head>
 
 <body>
-<ala:systemMessage/>
 
 	<div class="col-sm-12 col-md-9 col-lg-9">
 

--- a/grails-app/views/error.gsp
+++ b/grails-app/views/error.gsp
@@ -15,7 +15,6 @@
 </head>
 
 <body>
-<ala:systemMessage/>
 
 <div class="col-sm-12 col-md-9 col-lg-9">
 

--- a/grails-app/views/notfound.gsp
+++ b/grails-app/views/notfound.gsp
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta name="layout" content="main"/>
+	<meta name="layout" content="${grailsApplication.config.skin.layout}"/>
 	<title>ALA DOI Repository</title>
 
 	<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
@@ -15,7 +15,6 @@
 </head>
 
 <body>
-<ala:systemMessage/>
 
 <div class="col-sm-12 col-md-9 col-lg-9">
 

--- a/grails-app/views/unauthorised.gsp
+++ b/grails-app/views/unauthorised.gsp
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<meta name="layout" content="main"/>
+	<meta name="layout" content="${grailsApplication.config.skin.layout}"/>
 	<title>ALA DOI Repository</title>
 
 	<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
@@ -15,7 +15,6 @@
 </head>
 
 <body>
-<ala:systemMessage/>
 
 <div class="col-sm-12 col-md-9 col-lg-9">
 


### PR DESCRIPTION
Removed the `<ala:systemMessage/>` taglib from views (the system message in included in the `ala-main` layout)
added default layout to the notfound and unauthorised views

Note: any LA deployments use a layout that doesn't include the `<ala:systemMessage/>` will no longer display the system banner.

