### PR TITLE
issue #56 default doi minting provider

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -184,8 +184,10 @@ ala:
 doi:
     service:
         mock: false
-        # ANDS or DATACITE
-        provider: ANDS
+        provider:
+#            # define mapping from provider name to a valid DoiProvider (ANDS or DATACITE)
+            mapping: { ALA: 'DATACITE' }
+
     storage:
         provider: LOCAL
         cloud:

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -1,3 +1,4 @@
+import au.org.ala.doi.util.DoiProviderMapping
 import org.flywaydb.core.Flyway
 import org.springframework.beans.factory.config.BeanDefinition
 
@@ -28,6 +29,11 @@ beans = {
     }
     else {
         log.info "Grails Flyway plugin has been disabled"
+    }
+
+    // the configuration of the DOI mapping was not working Spring @Component injecting via @Value
+    doiProviderMapping(DoiProviderMapping) {
+        doiProviderMapping = application.config?.doi?.service?.provider?.mapping
     }
 }
 def addDependency(BeanDefinition beanDef, String dependencyName) {

--- a/grails-app/controllers/au/org/ala/doi/ui/AdminController.groovy
+++ b/grails-app/controllers/au/org/ala/doi/ui/AdminController.groovy
@@ -76,16 +76,15 @@ class AdminController {
             }
 
             def providerMetadata
-            def provider
             if (params?.newExistingDoiRadio == "existing") {
                 checkArgument params.existingDoi, "Existing DOI is required if registering an existing DOI"
-                provider = DoiProvider.byName(params.provider)
             } else {
                 checkArgument params.providerMetadata, "Provider metadata is required if minting a new DOI"
                 checkArgument params.provider, "Provider is required if minting a new DOI"
                 providerMetadata = JSON.parse(params.providerMetadata)
-                provider = DoiProvider.byName(params.provider)
             }
+
+            DoiProvider provider = DoiProvider.byName(params.provider)
 
             def userId = params.boolean('linkToUser', false) ? authService.userId : null
 

--- a/grails-app/domain/au/org/ala/doi/Doi.groovy
+++ b/grails-app/domain/au/org/ala/doi/Doi.groovy
@@ -2,7 +2,6 @@ package au.org.ala.doi
 
 import au.org.ala.doi.ArrayType
 import au.org.ala.doi.util.DoiProvider
-import grails.util.Holders
 import groovy.transform.EqualsAndHashCode
 import groovy.transform.ToString
 import net.kaleidos.hibernate.usertype.JsonbMapType
@@ -65,7 +64,6 @@ class Doi {
 
     static mapping = {
         doi type: CitextType
-        provider defaultValue: DoiProvider.byName(Holders.config.doi.service.provider as String)
         providerMetadata type: JsonbMapType
         applicationMetadata type: JsonbMapType
         active defaultValue: true

--- a/grails-app/services/au/org/ala/doi/DoiService.groovy
+++ b/grails-app/services/au/org/ala/doi/DoiService.groovy
@@ -54,7 +54,6 @@ class DoiService extends BaseDataAccessService {
 
         UUID uuid = UUID.randomUUID()
 
-
 //        String contentType = file ? file.contentType : new URL(fileUrl).openConnection().contentType
         Doi entity = new Doi(uuid: uuid, customLandingPageUrl: customLandingPageUrl, dateMinted: new Date(),
                 title: title, authors: authors, description: description, licence: licence, provider: provider,
@@ -203,7 +202,7 @@ class DoiService extends BaseDataAccessService {
 
     // Replace this with a factory if/when other DOI providers are supported
     private DoiProviderService getProviderService(DoiProvider provider) {
-        DoiProviderService service
+
         if (useMockDoiService) {
             log.info("Using mock provider service")
             return mockService
@@ -211,12 +210,11 @@ class DoiService extends BaseDataAccessService {
 
         switch (provider) {
             case DoiProvider.ANDS:
-                service = andsService
-                break
+                return andsService
             case DoiProvider.DATACITE:
-                service = dataCiteService
-                break
+                return dataCiteService
         }
-        service
+
+        throw new MissingResourceException("unsupported DoiProvider ${provider}", DoiService as String, provider as String)
     }
 }

--- a/src/main/groovy/au/org/ala/doi/util/DoiProvider.groovy
+++ b/src/main/groovy/au/org/ala/doi/util/DoiProvider.groovy
@@ -5,7 +5,19 @@ enum DoiProvider {
     ANDS,
     DATACITE
 
+    // list of at alternate names for the DoiProvider
+    List<String> altNames = []
+
     static DoiProvider byName(String name) {
-        values().find { it.name().equalsIgnoreCase(name) }
+        // lookup the provider by enum name
+        DoiProvider provider = values().find { it.name().equalsIgnoreCase(name) }
+
+        // no match, then lookup by alternate name
+        if (!provider) {
+            provider = values().find { it.altNames.any { String altName -> altName.equalsIgnoreCase(name) } }
+        }
+
+        return provider
     }
 }
+

--- a/src/main/groovy/au/org/ala/doi/util/DoiProviderMapping.groovy
+++ b/src/main/groovy/au/org/ala/doi/util/DoiProviderMapping.groovy
@@ -1,0 +1,44 @@
+package au.org.ala.doi.util
+
+import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+import javax.annotation.PostConstruct
+
+/**
+ * setup mapping of DoiProvider alternate names
+ */
+@Component
+@Slf4j
+class DoiProviderMapping {
+
+    @Value('#{${doi.service.provider.mapping:{ALA: \'DATACITE\' }}}')
+    Map<String, String> doiProviderMapping
+
+    @PostConstruct
+    void init() {
+
+        doiProviderMapping?.each { String altName, String providerName ->
+
+            DoiProvider doiProvider = DoiProvider.valueOf(providerName)
+
+            boolean existingAltName = DoiProvider.values().any { DoiProvider provider ->
+
+                if (provider.name().equalsIgnoreCase(altName)) {
+                    log.warn "provider alternate name '${altName}' matches DoiProvider.${provider.name()}"
+                    return true
+                } else if (provider.altNames.any { alt -> alt.equalsIgnoreCase(altName) }) {
+                    log.warn "provider alternate name '${altName}' already used by DoiProvider.${provider.name()}"
+                    return true
+                }
+
+                return false
+            }
+
+            if (!existingAltName) {
+                doiProvider.altNames << altName
+            }
+        }
+    }
+}

--- a/src/test/groovy/au/org/ala/doi/ws/DoiControllerSpec.groovy
+++ b/src/test/groovy/au/org/ala/doi/ws/DoiControllerSpec.groovy
@@ -7,6 +7,7 @@ import au.org.ala.doi.DoiService
 import au.org.ala.doi.MintResponse
 import au.org.ala.doi.storage.Storage
 import au.org.ala.doi.util.DoiProvider
+import au.org.ala.doi.util.DoiProviderMapping
 import com.google.common.io.ByteSource
 import com.google.common.io.Files
 import grails.converters.JSON
@@ -228,6 +229,29 @@ class DoiControllerSpec extends Specification implements ControllerUnitTest<DoiC
 
         then:
         1 * controller.doiService.mintDoi(DoiProvider.ANDS, [foo: "bar"], "title", "authors", "description", ["licence 1", "licence 2"], "http://example.org/applicationUrl", null, file, null, null, null, null, false, null, null) >> new MintResponse()
+    }
+
+    def "save should map provider if provided all metadata and the fileUrl for non-multipart requests"() {
+
+        setup:
+        DoiProviderMapping doiProviderMapping = new DoiProviderMapping()
+        doiProviderMapping.doiProviderMapping = [ ALA: 'DATACITE' ]
+        doiProviderMapping.init()
+
+        when:
+        request.JSON.provider = 'ALA'
+        request.JSON.applicationUrl = "http://example.org/applicationUrl"
+        request.JSON.providerMetadata = [foo: "bar"]
+        request.JSON.title = 'title'
+        request.JSON.authors = 'authors'
+        request.JSON.description = 'description'
+        request.JSON.fileUrl = "fileUrl"
+        request.JSON.userId = '1'
+        request.JSON.active = false
+        controller.save()
+
+        then:
+        1 * controller.doiService.mintDoi(DoiProvider.DATACITE, [foo: "bar"], "title", "authors", "description", null, "http://example.org/applicationUrl", "fileUrl", null, null, null, null, '1', false, null, null) >> new MintResponse()
     }
 
     def "search applies defaults to all parameters"() {


### PR DESCRIPTION
added ability to map a provider name to DoiProvider enum.

default configuration:
```
doi:
    service:
        provider:
            mapping: { ALA: 'DATACITE' }
```
this will map the provider name of `ALA` passed when minting a DOI to use the DATACITE provider. 