### PR TITLE
fall back to standard db monitoring in dev and test

### DIFF
--- a/cicd/database/config.ini
+++ b/cicd/database/config.ini
@@ -40,16 +40,10 @@ AUTO_DEPLOY = true
 DB_INSTANCE_NAME = ${PRODUCT_NAME}-${CLEAN_BRANCH}
 # uncomment the following line to restore from a snapshot
 #RDS_SNAPSHOT_RESTORE = arn:aws:rds:ap-southeast-2:748909248546:cluster-snapshot:ala-images-database-feature-rds-pipeline-updates-snapshot-dbcluster-wpangbshgwib
-DATABASE_INSIGHTS_MODE = advanced # "standard" or "enhanced"
-PERFORMANCE_INSIGHTS = true # true or false
-ENHANCED_MONITORING = 5 # enhanced monitoring interval in seconds. Set to 0 to disable.
 
 [testing]
 AUTO_DEPLOY = true
 # RDS
-DATABASE_INSIGHTS_MODE = advanced # "standard" or "enhanced"
-PERFORMANCE_INSIGHTS = true # true or false
-ENHANCED_MONITORING = 5 # enhanced monitoring interval in seconds. Set to 0 to disable.
 
 [staging]
 PERFORMANCE_INSIGHTS = true


### PR DESCRIPTION
The enhanced monitoring on the testing databases is generating an extra few thousand dollars of CloudWatch usage per year. The default is not to use enhanced monitoring so I've just removed the config for development and testing environments so we fall back to standard monitoring there. No issues turning back on when we need it but it's expensive to have running all the time. There have been no changes to production monitoring